### PR TITLE
Don't create whiteout files in opaque dirs.

### DIFF
--- a/main.c
+++ b/main.c
@@ -1065,6 +1065,9 @@ hide_node (struct ovl_data *lo, struct ovl_node *node, bool unlink_src)
             needs_whiteout = true;
         }
 
+      // if the parent directory is opaque, there's no need to put a whiteout in it.
+      needs_whiteout = needs_whiteout && (is_directory_opaque(get_upper_layer(lo), node->parent->path) < 1);
+
       if (needs_whiteout)
         {
           /* If the atomic rename+mknod failed, then fallback into doing it in two steps.  */

--- a/tests/fedora-installs.sh
+++ b/tests/fedora-installs.sh
@@ -231,3 +231,19 @@ if test -e upperdir/test/.wh.a.txt; then
    echo "whiteout file still exists" >&2
    exit 1
 fi
+
+# https://github.com/containers/fuse-overlayfs/issues/306
+
+rm -rf lower upper workdir merged
+mkdir lower upper workdir merged
+
+mkdir -p lower/a/b
+fuse-overlayfs -o lowerdir=lower,upperdir=upper,workdir=workdir merged
+
+rm -rf merged/a
+mkdir -p merged/a/b
+rm -rf merged/a/b
+test \! -e upper/a/b
+
+umount merged
+


### PR DESCRIPTION
If a dir is opaque, there's no need to create a whiteout within it as
the opacity will block out any files from lower dirs already anyways.

The kernel's overlay implementation also doesn't currently handle
whiteouts in opaque dirs very well (the whiteout shows up in readdir
calls but can't be stat'd), so this fix also improves compatibility
between fuse-overlay and the kernel's overlay a bit too.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>